### PR TITLE
CFLAGS isnt working with windows OS

### DIFF
--- a/make.m
+++ b/make.m
@@ -8,9 +8,15 @@ function make()
 %             mkoctfile --mex -g -I.. -I./others -I./problems -I./methods mexfiles/interface.cpp problems/*.cpp methods/stron.cpp others/helpers.cpp
             mex -g -I.. -I./others -I./problems -I./methods mexfiles/interface.cpp problems/logistic_regression.cpp problems/linear_svm.cpp methods/tron.cpp methods/stron.cpp methods/sqn.cpp methods/stron_svrg.cpp methods/stron_pcg.cpp methods/stron_pcg_prog.cpp methods/NewtonCG.cpp methods/lbfgs.cpp others/helpers.cpp
         else
-        % Compilation using MATLAB
-        % Need to add -largeArrayDims on 64-bit machines of MATLAB
-            mex CFLAGS="\$CFLAGS -std=c99" -g -I./others -I./problems -I./methods -largeArrayDims mexfiles/interface.cpp problems/*.cpp methods/*.cpp others/helpers.cpp            
+            if ispc
+                % Compilation using MATLAB (FOR WINDOWS)
+                % Need to add -largeArrayDims on 64-bit machines of MATLAB
+                mex COMPFLAGS="\$COMPFLAGS -std=c99" -g -I./others -I./problems -I./methods -largeArrayDims mexfiles/interface.cpp problems/*.cpp methods/*.cpp others/helpers.cpp            
+            else     
+                % Compilation using MATLAB 
+                % Need to add -largeArrayDims on 64-bit machines of MATLAB
+                mex CFLAGS="\$CFLAGS -std=c99" -g -I./others -I./problems -I./methods -largeArrayDims mexfiles/interface.cpp problems/*.cpp methods/*.cpp others/helpers.cpp            
+            end
         end
     catch err
         fprintf('Error in Compilation: %s failed (line %d)\n', err.stack(1).file, err.stack(1).line);


### PR DESCRIPTION
CFLAGS in windows 10 doesn't work that gives following error
 "error: -fexceptions: No such file or directory."
that's why used COMPFLAGS instead